### PR TITLE
[Fix] Sync state

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperplay/quests-ui",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/state/QuestPlayStreakSyncState.ts
+++ b/src/state/QuestPlayStreakSyncState.ts
@@ -24,7 +24,7 @@ class QuestPlayStreakSyncState {
     string,
     {
       syncTimers: NodeJS.Timeout[]
-      intervalTimers: NodeJS.Timer[]
+      intervalTimers: NodeJS.Timeout[]
     }
   > = {}
 
@@ -92,6 +92,11 @@ class QuestPlayStreakSyncState {
         const syncThisProjectMutation = async () =>
           this.queryClient?.fetchQuery({
             queryKey: getSyncPlaysessionQueryKey(projectId),
+            /**
+             * if multiple quests are syncing at the same time (within 1 second), we want to only send once.
+             * if one quest finishes in 40 seconds and another in 41 seconds, then we want to post at 40 and 41 sec
+             */
+            staleTime: 500,
             queryFn: async () => {
               this.syncPlaySession(
                 projectId,
@@ -105,6 +110,7 @@ class QuestPlayStreakSyncState {
                 )
                 this.appQueryClient?.invalidateQueries({ queryKey })
               }
+              return null
             }
           })
 
@@ -114,11 +120,9 @@ class QuestPlayStreakSyncState {
         const minimumRequiredPlayTimeInSeconds =
           questMeta?.eligibility?.play_streak.minimum_session_time_in_seconds
         if (
-          minimumRequiredPlayTimeInSeconds &&
-          currentPlayTimeInSeconds &&
+          minimumRequiredPlayTimeInSeconds !== undefined &&
           currentPlayTimeInSeconds < minimumRequiredPlayTimeInSeconds
         ) {
-          console.log('setting timeout for post mutation')
           const finalSyncTimer = setTimeout(
             syncThisProjectMutation,
             minimumRequiredPlayTimeInSeconds - currentPlayTimeInSeconds
@@ -130,7 +134,7 @@ class QuestPlayStreakSyncState {
           syncThisProjectMutation,
           this.intervalSyncTick
         )
-        this.projectSyncData[projectId].syncTimers.push(intervalId)
+        this.projectSyncData[projectId].intervalTimers.push(intervalId)
       } catch (err) {
         console.error(`Error while setting up playstreak sync: ${err}`)
       }

--- a/src/state/QuestPlayStreakSyncState.ts
+++ b/src/state/QuestPlayStreakSyncState.ts
@@ -121,6 +121,9 @@ class QuestPlayStreakSyncState {
           questMeta?.eligibility?.play_streak.minimum_session_time_in_seconds
         if (
           minimumRequiredPlayTimeInSeconds !== undefined &&
+          minimumRequiredPlayTimeInSeconds !== null &&
+          currentPlayTimeInSeconds !== undefined &&
+          currentPlayTimeInSeconds !== null &&
           currentPlayTimeInSeconds < minimumRequiredPlayTimeInSeconds
         ) {
           const finalSyncTimer = setTimeout(


### PR DESCRIPTION
# Summary

Fix 
- bug where `currentPlayTimeInSeconds = 0` causes the quest end timeout to not be set
- cache time was too long so some quests weren't completed at their end time
- `intervalTimers` push
- console error complaining that fetch query was not returning a value, so now we return `null`

related to https://github.com/HyperPlay-Gaming/product-management/issues/657