### PR TITLE
[Chore] update hp utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
   "peerDependencies": {
     "@hyperplay/chains": "^0.3.0",
     "@hyperplay/ui": "^1.7.17",
+    "@hyperplay/utils": "^0.3.4",
     "@tanstack/query-core": "^5.59.20",
     "@tanstack/react-query": "^5.59.20",
     "i18next": "^23.12.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperplay/quests-ui",
-  "version": "0.0.37",
+  "version": "0.0.38",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -30,7 +30,7 @@
     "@chromatic-com/storybook": "^1.9.0",
     "@hyperplay/chains": "^0.3.0",
     "@hyperplay/ui": "^1.8.4",
-    "@hyperplay/utils": "^0.2.7",
+    "@hyperplay/utils": "^0.3.4",
     "@mantine/core": "^7.5.1",
     "@storybook/addon-essentials": "^8.3.4",
     "@storybook/addon-interactions": "^8.3.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,8 +22,8 @@ importers:
         specifier: ^1.8.4
         version: 1.8.4(@emotion/react@11.13.0(@types/react@18.3.3)(react@18.3.1))(@mantine/carousel@7.12.1(@mantine/core@7.13.1(@mantine/hooks@7.12.1(react@18.3.1))(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mantine/hooks@7.12.1(react@18.3.1))(embla-carousel-react@8.1.8(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mantine/core@7.13.1(@mantine/hooks@7.12.1(react@18.3.1))(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mantine/dropzone@7.12.1(@mantine/core@7.13.1(@mantine/hooks@7.12.1(react@18.3.1))(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mantine/hooks@7.12.1(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mantine/hooks@7.12.1(react@18.3.1))(embla-carousel-autoplay@8.1.8(embla-carousel@8.1.8))(embla-carousel-react@8.1.8(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react-markdown@9.0.1(@types/react@18.3.3)(react@18.3.1))(react@18.3.1)
       '@hyperplay/utils':
-        specifier: ^0.2.7
-        version: 0.2.7
+        specifier: ^0.3.4
+        version: 0.3.4
       '@mantine/core':
         specifier: ^7.5.1
         version: 7.13.1(@mantine/hooks@7.12.1(react@18.3.1))(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1170,8 +1170,8 @@ packages:
       react-dom: ^17.0.0 || ^18.0.0
       react-markdown: 9.0.1
 
-  '@hyperplay/utils@0.2.7':
-    resolution: {integrity: sha512-FnypQrdu1C3YWP6OB6/jjKSRJhq8CTgarRFd1pLPc7omwr8SElq6WgaJ5A9b8ibCycBtf+lIvdc/r2k6pFRZrw==}
+  '@hyperplay/utils@0.3.4':
+    resolution: {integrity: sha512-ndkDnp+iV9BlLCKpbq0XVuuc/ORzaZ+69wFvVvAftdU6mbwbk4EfxAwTOpmXWkLaiGp0MZaybYMa5zYZkxkW5w==}
 
   '@isaacs/ttlcache@1.4.1':
     resolution: {integrity: sha512-RQgQ4uQ+pLbqXfOmieB91ejmLwvSgv9nLx6sT6sD83s7umBypgg+OIBOBbEUiJXrfpnp9j0mRhYYdzp9uqq3lA==}
@@ -8170,7 +8170,7 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       react-markdown: 9.0.1(@types/react@18.3.3)(react@18.3.1)
 
-  '@hyperplay/utils@0.2.7':
+  '@hyperplay/utils@0.3.4':
     dependencies:
       bignumber.js: 9.1.2
 


### PR DESCRIPTION
the quest type mismatch is breaking codecheck on my branch https://github.com/HyperPlay-Gaming/hyperplay-desktop-client/actions/runs/11733793835/job/32688719172?pr=1124

also since we are using `getDecimalNumberFromAmount` and not just the types from hp utils, this needs to be a peer dependency