### PR TITLE
[Fix] wagmi switch chain claim error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperplay/quests-ui",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperplay/quests-ui",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/components/RewardWrapper/index.tsx
+++ b/src/components/RewardWrapper/index.tsx
@@ -17,7 +17,13 @@ import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { createPublicClient, http } from 'viem'
-import { useAccount, useConfig, useConnect, useSwitchChain, useWriteContract } from 'wagmi'
+import {
+  useAccount,
+  useConfig,
+  useConnect,
+  useSwitchChain,
+  useWriteContract
+} from 'wagmi'
 import { injected } from 'wagmi/connectors'
 import { ConfirmClaimModal } from '../ConfirmClaimModal'
 import styles from './index.module.scss'
@@ -221,8 +227,10 @@ export function RewardWrapper({
      * We need to check that the switch chain method exists before proceeding with claiming.
      */
     let connectionHasSwitchChain = false
-    if (config.state.current){
-      const currentConnection = config.state.connections.get(config.state.current)
+    if (config.state.current) {
+      const currentConnection = config.state.connections.get(
+        config.state.current
+      )
       connectionHasSwitchChain = !!currentConnection?.connector.switchChain
     }
 
@@ -233,6 +241,7 @@ export function RewardWrapper({
       logInfo('connecting to wallet...')
       const { accounts } = await connectAsync({ connector: injected() })
       address = accounts[0]
+    }
     if (!address) {
       throw Error('no address found when trying to mint')
     }


### PR DESCRIPTION
see https://github.com/HyperPlay-Gaming/hyperplay-desktop-client/pull/1185 and https://github.com/HyperPlay-Gaming/product-management/issues/801

Something about our client implemenation or a wagmi bug is causing the address to be set but no connection is established. It is stuck in `reconnecting` status, so perhaps it connects, get the address, and then loses the connection object but keeps the address on the config object.

We can just make the same check that wagmi does in switch chain and call `connectAsync` if it fails to ensure the connection is made to wagmi