### PR TITLE
feat(gameplay-wallet): address quest UI PR comments

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperplay/quests-ui",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/components/ActiveWalletSection/index.tsx
+++ b/src/components/ActiveWalletSection/index.tsx
@@ -197,16 +197,16 @@ export default function ActiveWalletSection() {
   })
 
   const onlyConnectedWallet = (
-    <InfoAlert title={t('wallet.detected.title', 'Wallet Detected')}>
+    <InfoAlert title={t('gameplayWallet.detected.title', 'Wallet Detected')}>
       <span className="body-sm">
         {t(
-          'wallet.detected.message',
+          'gameplayWallet.detected.message',
           'To track progress with this wallet, add it as a Gameplay Wallet below by setting it.'
         )}
       </span>{' '}
       <span className={cn('body-sm', styles.verifyText)}>
         {t(
-          'wallet.verify.message',
+          'gameplayWallet.verify.message',
           'You only need to verify each address once and can switch freely at any time.'
         )}
       </span>
@@ -292,6 +292,11 @@ export default function ActiveWalletSection() {
   const hasDifferentWallets =
     Boolean(activeWallet && connectedWallet) && !hasMatchingWallets
 
+  const isNewWalletDetected =
+    activeWallet &&
+    gameplayWallets &&
+    !gameplayWallets.some((wallet) => wallet.wallet_address === activeWallet)
+
   let content = null
 
   if (hasNoWallets) {
@@ -349,7 +354,8 @@ export default function ActiveWalletSection() {
   if (hasMatchingWallets) {
     content = (
       <InputLikeContainer
-        title={t('gameplayWallet.connected.title', 'Active Wallet')}
+        title={t('gameplayWallet.active.title', 'Active Gameplay Wallet')}
+        tooltip={<ActiveWalletInfoTooltip />}
       >
         <InputLikeBox className={styles.activeWallet}>
           {truncateEthAddress(activeWallet ?? '')}
@@ -361,7 +367,7 @@ export default function ActiveWalletSection() {
   if (hasDifferentWallets) {
     content = (
       <>
-        {newWalletDetected}
+        {isNewWalletDetected ? newWalletDetected : null}
         <InputLikeContainer
           title={t('gameplayWallet.active.title', 'Active Gameplay Wallet')}
           tooltip={<ActiveWalletInfoTooltip />}

--- a/src/components/ActiveWalletSection/index.tsx
+++ b/src/components/ActiveWalletSection/index.tsx
@@ -136,8 +136,8 @@ export default function ActiveWalletSection() {
 
   const invalidateQueries = () => {
     queryClient.invalidateQueries({
-      predicate: (query) => 
-        query.queryKey[0] === 'activeWallet' || 
+      predicate: (query) =>
+        query.queryKey[0] === 'activeWallet' ||
         query.queryKey[0] === 'gameplayWallets'
     })
   }

--- a/src/components/ActiveWalletSection/index.tsx
+++ b/src/components/ActiveWalletSection/index.tsx
@@ -151,8 +151,8 @@ export default function ActiveWalletSection() {
         })
       }
 
-      if (!response.ok) {
-        throw new Error(await response.text())
+      if (!response.success) {
+        throw new Error(response.message)
       }
 
       await queryClient.invalidateQueries({
@@ -224,7 +224,7 @@ export default function ActiveWalletSection() {
       {isPending ? (
         <LoadingSpinner className={styles.loadingSpinner} />
       ) : (
-        t('wallet.action.set', 'Set')
+        t('gameplayWallet.action.set', 'Set')
       )}
     </Button>
   )

--- a/src/components/QuestDetailsWrapper/PlayStreakQuest.stories.tsx
+++ b/src/components/QuestDetailsWrapper/PlayStreakQuest.stories.tsx
@@ -96,7 +96,7 @@ const mockProps: QuestDetailsWrapperProps = {
   },
   setActiveWallet: async (wallet) => {
     alert(`setActiveWallet ${wallet}`)
-    return new Response('OK')
+    return { success: true, status: 200 }
   },
   onRewardClaimed: () => {
     alert('This is when we show the claim success modal')
@@ -278,7 +278,7 @@ export const ActiveWalletConnectDefault: Story = {
           setActiveWallet(wallet)
           // wait for wallet state to be updated so that the query is invalidated (this is only because we're mocking a remote state with a local react state)
           await new Promise((resolve) => setTimeout(resolve, 1000))
-          return new Response('OK')
+          return { success: true, status: 200 }
         }}
       />
     )
@@ -302,7 +302,7 @@ export const ActiveWalletSwitchWallet: Story = {
           setActiveWallet(wallet)
           // wait for wallet state to be updated so that the query is invalidated (this is only because we're mocking a remote state with a local react state)
           await new Promise((resolve) => setTimeout(resolve, 1000))
-          return new Response('OK')
+          return { success: true, status: 200 }
         }}
       />
     )
@@ -319,7 +319,7 @@ export const ActiveWalletSwitchWalletError: Story = {
         {...args}
         setActiveWallet={async () => {
           await new Promise((resolve) => setTimeout(resolve, 1000))
-          return new Response('Error', { status: 500 })
+          return { success: false, status: 500, message: 'Error' }
         }}
       />
     )
@@ -336,7 +336,7 @@ export const ActiveWalletSwitchWalletAlreadyLinked: Story = {
         {...args}
         setActiveWallet={async () => {
           await new Promise((resolve) => setTimeout(resolve, 1000))
-          return new Response(null, { status: 409 })
+          return { success: false, status: 409, message: 'Wallet already linked' }
         }}
       />
     )

--- a/src/components/QuestDetailsWrapper/PlayStreakQuest.stories.tsx
+++ b/src/components/QuestDetailsWrapper/PlayStreakQuest.stories.tsx
@@ -316,6 +316,40 @@ export const ActiveWalletSwitchWallet: Story = {
   }
 }
 
+export const ActiveWalletSwitchWalletAlreadyLinked: Story = {
+  args: {
+    ...mockProps
+  },
+  render: (args) => {
+    const { addresses, address } = useAccount()
+    const [activeWallet, setActiveWallet] = useState<string | null>()
+    return (
+      <QuestDetailsWrapper
+        key={address}
+        {...args}
+        getGameplayWallets={async () =>
+          addresses?.map((address, index) => ({
+            id: index,
+            wallet_address: address
+          })) ?? []
+        }
+        getActiveWallet={async () => Promise.resolve(activeWallet)}
+        updateActiveWallet={async () => {
+          setActiveWallet(address)
+          await new Promise((resolve) => setTimeout(resolve, 1000))
+        }}
+        setActiveWallet={async ({ message, signature }) => {
+          const wallet = verifyMessage(message, signature)
+          setActiveWallet(wallet)
+          // wait for wallet state to be updated so that the query is invalidated (this is only because we're mocking a remote state with a local react state)
+          await new Promise((resolve) => setTimeout(resolve, 1000))
+          return { success: true, status: 200 }
+        }}
+      />
+    )
+  }
+}
+
 export const ActiveWalletSwitchWalletError: Story = {
   args: {
     ...mockProps

--- a/src/components/QuestDetailsWrapper/PlayStreakQuest.stories.tsx
+++ b/src/components/QuestDetailsWrapper/PlayStreakQuest.stories.tsx
@@ -5,6 +5,7 @@ import { Quest, UserPlayStreak } from '@hyperplay/utils'
 import { useState } from 'react'
 import { verifyMessage, BrowserProvider } from 'ethers'
 import { generateNonce, SiweMessage } from 'siwe'
+import { useAccount } from 'wagmi'
 
 const meta: Meta<typeof QuestDetailsWrapper> = {
   component: QuestDetailsWrapper,
@@ -114,6 +115,12 @@ const mockProps: QuestDetailsWrapperProps = {
   onPlayClick: () => alert('onPlayClick'),
   getQuest: async () => {
     return mockQuest
+  },
+  getGameplayWallets: async () => {
+    return []
+  },
+  updateActiveWallet: async () => {
+    return Promise.resolve()
   },
   getUserPlayStreak: async () => {
     return mockUserPlayStreak
@@ -326,7 +333,7 @@ export const ActiveWalletSwitchWalletError: Story = {
   }
 }
 
-export const ActiveWalletSwitchWalletAlreadyLinked: Story = {
+export const ActiveWalletSwitchWalletAlreadyLinkedToAnotherAccount: Story = {
   args: {
     ...mockProps
   },
@@ -336,7 +343,36 @@ export const ActiveWalletSwitchWalletAlreadyLinked: Story = {
         {...args}
         setActiveWallet={async () => {
           await new Promise((resolve) => setTimeout(resolve, 1000))
-          return { success: false, status: 409, message: 'Wallet already linked' }
+          return {
+            success: false,
+            status: 409,
+            message: 'Wallet already linked'
+          }
+        }}
+      />
+    )
+  }
+}
+
+export const ActiveWalletSwitchWalletExistingWalletSkipSignature: Story = {
+  args: {
+    ...mockProps
+  },
+  render: (args) => {
+    const [activeWallet, setActiveWallet] = useState<string | null>(null)
+    const { address } = useAccount()
+    console.log('activeWallet', activeWallet)
+    return (
+      <QuestDetailsWrapper
+        key={address}
+        {...args}
+        getActiveWallet={async () => Promise.resolve(activeWallet)}
+        getGameplayWallets={async () => [
+          { id: 1, wallet_address: address ?? '' }
+        ]}
+        updateActiveWallet={async () => {
+          console.log('updateActiveWallet', address)
+          setActiveWallet(address ?? '')
         }}
       />
     )

--- a/src/types/quests.ts
+++ b/src/types/quests.ts
@@ -50,7 +50,7 @@ export interface QuestWrapperContextValue {
   }: {
     message: string
     signature: string
-  }) => Promise<Response>
+  }) => Promise<{ success: boolean; status: number; message?: string }>
   getUserPlayStreak: (questId: number) => Promise<UserPlayStreak>
   getSteamGameMetadata: (id: number) => Promise<{
     name?: string

--- a/src/types/quests.ts
+++ b/src/types/quests.ts
@@ -40,6 +40,8 @@ export interface QuestWrapperContextValue {
   }
   getQuest: (questId: number) => Promise<Quest>
   getActiveWallet: () => Promise<string | null | undefined>
+  getGameplayWallets: () => Promise<{ id: number; wallet_address: string }[]>
+  updateActiveWallet: (walletId: number) => Promise<void>
   getActiveWalletSignature: () => Promise<{
     message: string
     signature: string


### PR DESCRIPTION
follow up of https://github.com/HyperPlay-Gaming/quests-ui/pull/42

- adds a check for existing gameplay wallets to prevent asking for signature for addresses already added
- update alert toasts texts