### PR TITLE
feat: add functions needed to filter claims in the client

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperplay/quests-ui",
-  "version": "0.1.36",
+  "version": "0.1.37",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperplay/quests-ui",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/components/ActiveWalletSection/index.tsx
+++ b/src/components/ActiveWalletSection/index.tsx
@@ -10,6 +10,8 @@ import { InfoAlertProps } from '@hyperplay/ui/dist/components/AlertCard'
 import { Popover } from '@mantine/core'
 import { useDisclosure } from '@mantine/hooks'
 import { useGetActiveWallet } from '@/hooks/useGetActiveWallet'
+import { getGetExternalEligibilityQueryKey } from '@/helpers/getQueryKeys'
+
 function ActiveWalletInfoTooltip() {
   const { tOverride } = useQuestWrapper()
   const [opened, { close, open }] = useDisclosure(false)
@@ -134,7 +136,8 @@ export default function ActiveWalletSection() {
     queryClient.invalidateQueries({
       predicate: (query) =>
         query.queryKey[0] === 'activeWallet' ||
-        query.queryKey[0] === 'gameplayWallets'
+        query.queryKey[0] === 'gameplayWallets' ||
+        query.queryKey[0] === getGetExternalEligibilityQueryKey(null)[0] // we don't really care for the questId here
     })
   }
 

--- a/src/components/RewardsBanner/LeaderboardBanner/index.tsx
+++ b/src/components/RewardsBanner/LeaderboardBanner/index.tsx
@@ -119,6 +119,6 @@ export function LeaderboardBanner({
     )
     return userCanClaimReward ? claimableMessage : notEligibleMessage
   }
-  
+
   return null
 }

--- a/src/components/RewardsBanner/LeaderboardBanner/index.tsx
+++ b/src/components/RewardsBanner/LeaderboardBanner/index.tsx
@@ -119,10 +119,13 @@ export function LeaderboardBanner({
     return finalizingMessage
   }
 
-  if (!eligibilityData) {
+  if (!eligibilityData?.externalEligibility) {
     return notEligibleMessage
   }
 
-  const userCanClaimReward = canClaimLeaderboardReward(quest, eligibilityData)
+  const userCanClaimReward = canClaimLeaderboardReward(
+    quest,
+    eligibilityData.externalEligibility
+  )
   return userCanClaimReward ? claimableMessage : notEligibleMessage
 }

--- a/src/helpers/getExternalQuestStatus.test.ts
+++ b/src/helpers/getExternalQuestStatus.test.ts
@@ -37,13 +37,13 @@ describe('getExternalQuestStatus', () => {
     expect(result).toBe('ACTIVE')
   })
 
-  it('returns undefined when quest is CLAIMABLE but has no external eligibility', () => {
+  it('returns undefined to hide quest when quest is CLAIMABLE but has no external eligibility', () => {
     const quest = mockQuest('CLAIMABLE')
     const result = getExternalQuestStatus(quest, null)
     expect(result).toBeUndefined()
   })
 
-  it('returns undefined when quest is CLAIMABLE and cannot claim reward', () => {
+  it('returns undefined to hide quest when quest is CLAIMABLE and cannot claim reward', () => {
     const quest = mockQuest('CLAIMABLE')
     const externalEligibility = mockExternalEligibility(0)
     const result = getExternalQuestStatus(quest, externalEligibility)
@@ -57,7 +57,7 @@ describe('getExternalQuestStatus', () => {
     expect(result).toBe('READY_FOR_CLAIM')
   })
 
-  it('returns undefined when quest status is COMPLETED', () => {
+  it('returns undefined to hide quest when quest status is COMPLETED', () => {
     const quest = mockQuest('COMPLETED')
     const result = getExternalQuestStatus(quest, null)
     expect(result).toBeUndefined()

--- a/src/helpers/getExternalQuestStatus.test.ts
+++ b/src/helpers/getExternalQuestStatus.test.ts
@@ -1,0 +1,61 @@
+import { ExternalEligibility, Quest } from '@hyperplay/utils'
+import { getExternalQuestStatus } from './getExternalQuestStatus'
+import { expect, it, describe } from 'vitest'
+
+describe('getExternalQuestStatus', () => {
+  const mockQuest = (status: Quest['status']): Quest => ({
+    id: 1,
+    project_id: '0123',
+    name: 'Test Quest',
+    type: 'LEADERBOARD',
+    status,
+    description: 'Test Description',
+    deposit_contracts: [],
+    quest_external_game: null,
+    num_of_times_repeatable: 1,
+    eligibility: {
+      completion_threshold: 10,
+      steam_games: [{ id: '123' }],
+      play_streak: {
+        required_playstreak_in_days: 1,
+        minimum_session_time_in_seconds: 100
+      }
+    },
+    start_date: null,
+    end_date: null,
+    leaderboard_url: 'https://example.com'
+  })
+
+  const mockExternalEligibility = (amount: number): ExternalEligibility => ({
+    amount,
+    walletOrEmail: 'test@example.com'
+  })
+
+  it('returns READY_FOR_CLAIM when canClaimLeaderboardReward is true', () => {
+    const quest = mockQuest('CLAIMABLE')
+    const externalEligibility = mockExternalEligibility(100)
+    const result = getExternalQuestStatus(quest, externalEligibility)
+    expect(result).toBe('READY_FOR_CLAIM')
+  })
+
+  it('returns undefined when quest status is COMPLETED', () => {
+    const quest = mockQuest('COMPLETED')
+    const externalEligibility = mockExternalEligibility(0)
+    const result = getExternalQuestStatus(quest, externalEligibility)
+    expect(result).toBeUndefined()
+  })
+
+  it('returns ACTIVE when quest status is ACTIVE and cannot claim', () => {
+    const quest = mockQuest('ACTIVE')
+    const externalEligibility = mockExternalEligibility(0)
+    const result = getExternalQuestStatus(quest, externalEligibility)
+    expect(result).toBe('ACTIVE')
+  })
+
+  it('prioritizes READY_FOR_CLAIM over ACTIVE status', () => {
+    const quest = mockQuest('CLAIMABLE')
+    const externalEligibility = mockExternalEligibility(100)
+    const result = getExternalQuestStatus(quest, externalEligibility)
+    expect(result).toBe('READY_FOR_CLAIM')
+  })
+})

--- a/src/helpers/getExternalQuestStatus.test.ts
+++ b/src/helpers/getExternalQuestStatus.test.ts
@@ -3,7 +3,7 @@ import { getExternalQuestStatus } from './getExternalQuestStatus'
 import { expect, it, describe } from 'vitest'
 
 describe('getExternalQuestStatus', () => {
-  const mockQuest = (status: Quest['status'], endDate?: string): Quest => ({
+  const mockQuest = (status: Quest['status']): Quest => ({
     id: 1,
     project_id: '0123',
     name: 'Test Quest',
@@ -22,7 +22,7 @@ describe('getExternalQuestStatus', () => {
       }
     },
     start_date: null,
-    end_date: endDate || null,
+    end_date: null,
     leaderboard_url: 'https://example.com'
   })
 
@@ -37,31 +37,21 @@ describe('getExternalQuestStatus', () => {
     expect(result).toBe('ACTIVE')
   })
 
-  it('returns ACTIVE when quest is CLAIMABLE but has not ended', () => {
-    const futureDate = new Date(Date.now() + 86400000).toISOString()
-    const quest = mockQuest('CLAIMABLE', futureDate)
-    const result = getExternalQuestStatus(quest, null)
-    expect(result).toBe('ACTIVE')
-  })
-
-  it('returns undefined when quest is CLAIMABLE, has ended, but has no external eligibility', () => {
-    const pastDate = new Date(Date.now() - 86400000).toISOString()
-    const quest = mockQuest('CLAIMABLE', pastDate)
+  it('returns undefined when quest is CLAIMABLE but has no external eligibility', () => {
+    const quest = mockQuest('CLAIMABLE')
     const result = getExternalQuestStatus(quest, null)
     expect(result).toBeUndefined()
   })
 
-  it('returns undefined when quest is CLAIMABLE, has ended, and cannot claim reward', () => {
-    const pastDate = new Date(Date.now() - 86400000).toISOString()
-    const quest = mockQuest('CLAIMABLE', pastDate)
+  it('returns undefined when quest is CLAIMABLE and cannot claim reward', () => {
+    const quest = mockQuest('CLAIMABLE')
     const externalEligibility = mockExternalEligibility(0)
     const result = getExternalQuestStatus(quest, externalEligibility)
     expect(result).toBeUndefined()
   })
 
-  it('returns READY_FOR_CLAIM when quest is CLAIMABLE, has ended, and can claim reward', () => {
-    const pastDate = new Date(Date.now() - 86400000).toISOString()
-    const quest = mockQuest('CLAIMABLE', pastDate)
+  it('returns READY_FOR_CLAIM when quest is CLAIMABLE and can claim reward', () => {
+    const quest = mockQuest('CLAIMABLE')
     const externalEligibility = mockExternalEligibility(100)
     const result = getExternalQuestStatus(quest, externalEligibility)
     expect(result).toBe('READY_FOR_CLAIM')

--- a/src/helpers/getExternalQuestStatus.test.ts
+++ b/src/helpers/getExternalQuestStatus.test.ts
@@ -64,7 +64,7 @@ describe('getExternalQuestStatus', () => {
   })
 
   it.each(['INACTIVE', 'DRAFT'] as Quest['status'][])(
-    'returns undefined for other quest statuses',
+    'returns undefined to hide quest when quest status is %s',
     (status) => {
       const quest = mockQuest(status)
       const result = getExternalQuestStatus(quest, null)

--- a/src/helpers/getExternalQuestStatus.test.ts
+++ b/src/helpers/getExternalQuestStatus.test.ts
@@ -72,4 +72,4 @@ describe('getExternalQuestStatus', () => {
     const result = getExternalQuestStatus(quest, null)
     expect(result).toBeUndefined()
   })
-}) 
+})

--- a/src/helpers/getExternalQuestStatus.test.ts
+++ b/src/helpers/getExternalQuestStatus.test.ts
@@ -57,9 +57,18 @@ describe('getExternalQuestStatus', () => {
     expect(result).toBe('READY_FOR_CLAIM')
   })
 
-  it('returns undefined to hide quest when quest status is COMPLETED', () => {
+  it('returns ACTIVE when quest status is COMPLETED', () => {
     const quest = mockQuest('COMPLETED')
     const result = getExternalQuestStatus(quest, null)
-    expect(result).toBeUndefined()
+    expect(result).toBe('ACTIVE')
   })
+
+  it.each(['INACTIVE', 'DRAFT'] as Quest['status'][])(
+    'returns undefined for other quest statuses',
+    (status) => {
+      const quest = mockQuest(status)
+      const result = getExternalQuestStatus(quest, null)
+      expect(result).toBeUndefined()
+    }
+  )
 })

--- a/src/helpers/getExternalQuestStatus.ts
+++ b/src/helpers/getExternalQuestStatus.ts
@@ -2,15 +2,12 @@ import { QuestLogInfo } from '@hyperplay/ui'
 import { ExternalEligibility, Quest } from '@hyperplay/utils'
 import { canClaimLeaderboardReward } from './canClaimReward'
 
+// TODO: handle claimed
 export function getExternalQuestStatus(
   quest: Quest,
   externalEligibility: ExternalEligibility | null
 ): QuestLogInfo['state'] | undefined {
-  if (quest.status === 'COMPLETED') {
-    return undefined
-  }
-
-  if (quest.status === 'ACTIVE') {
+  if (quest.status === 'ACTIVE' || quest.status === 'COMPLETED') {
     return 'ACTIVE'
   }
 
@@ -24,4 +21,6 @@ export function getExternalQuestStatus(
 
     return 'READY_FOR_CLAIM'
   }
+
+  return undefined
 }

--- a/src/helpers/getExternalQuestStatus.ts
+++ b/src/helpers/getExternalQuestStatus.ts
@@ -1,17 +1,34 @@
 import { QuestLogInfo } from '@hyperplay/ui'
 import { ExternalEligibility, Quest } from '@hyperplay/utils'
 import { canClaimLeaderboardReward } from './canClaimReward'
+import dayjs from 'dayjs'
 
 export function getExternalQuestStatus(
   quest: Quest,
-  externalEligibility: ExternalEligibility
+  externalEligibility: ExternalEligibility | null
 ): QuestLogInfo['state'] | undefined {
-  const canClaim = canClaimLeaderboardReward(quest, externalEligibility)
-  if (canClaim) {
-    return 'READY_FOR_CLAIM'
-  } else if (quest.status === 'COMPLETED') {
+  const questEnded = quest.end_date
+    ? dayjs(quest.end_date).isBefore(dayjs())
+    : false
+
+  if (quest.status === 'COMPLETED') {
     return undefined
-  } else if (quest.status === 'ACTIVE') {
+  }
+
+  if (quest.status === 'ACTIVE') {
     return 'ACTIVE'
+  }
+
+  if (quest.status === 'CLAIMABLE') {
+    if (!questEnded) {
+      return 'ACTIVE'
+    }
+
+    if (!externalEligibility) {
+      return undefined
+    }
+
+    const canClaim = canClaimLeaderboardReward(quest, externalEligibility)
+    return canClaim ? 'READY_FOR_CLAIM' : undefined
   }
 }

--- a/src/helpers/getExternalQuestStatus.ts
+++ b/src/helpers/getExternalQuestStatus.ts
@@ -13,13 +13,13 @@ export function getExternalQuestStatus(
 
   if (quest.status === 'CLAIMABLE') {
     if (
-      !externalEligibility ||
-      !canClaimLeaderboardReward(quest, externalEligibility)
+      externalEligibility &&
+      canClaimLeaderboardReward(quest, externalEligibility)
     ) {
-      return undefined
+      return 'READY_FOR_CLAIM'
     }
 
-    return 'READY_FOR_CLAIM'
+    return undefined
   }
 
   return undefined

--- a/src/helpers/getExternalQuestStatus.ts
+++ b/src/helpers/getExternalQuestStatus.ts
@@ -1,16 +1,11 @@
 import { QuestLogInfo } from '@hyperplay/ui'
 import { ExternalEligibility, Quest } from '@hyperplay/utils'
 import { canClaimLeaderboardReward } from './canClaimReward'
-import dayjs from 'dayjs'
 
 export function getExternalQuestStatus(
   quest: Quest,
   externalEligibility: ExternalEligibility | null
 ): QuestLogInfo['state'] | undefined {
-  const questEnded = quest.end_date
-    ? dayjs(quest.end_date).isBefore(dayjs())
-    : false
-
   if (quest.status === 'COMPLETED') {
     return undefined
   }
@@ -20,15 +15,13 @@ export function getExternalQuestStatus(
   }
 
   if (quest.status === 'CLAIMABLE') {
-    if (!questEnded) {
-      return 'ACTIVE'
-    }
-
-    if (!externalEligibility) {
+    if (
+      !externalEligibility ||
+      !canClaimLeaderboardReward(quest, externalEligibility)
+    ) {
       return undefined
     }
 
-    const canClaim = canClaimLeaderboardReward(quest, externalEligibility)
-    return canClaim ? 'READY_FOR_CLAIM' : undefined
+    return 'READY_FOR_CLAIM'
   }
 }

--- a/src/helpers/getExternalQuestStatus.ts
+++ b/src/helpers/getExternalQuestStatus.ts
@@ -1,0 +1,17 @@
+import { QuestLogInfo } from '@hyperplay/ui'
+import { ExternalEligibility, Quest } from '@hyperplay/utils'
+import { canClaimLeaderboardReward } from './canClaimReward'
+
+export function getExternalQuestStatus(
+  quest: Quest,
+  externalEligibility: ExternalEligibility
+): QuestLogInfo['state'] | undefined {
+  const canClaim = canClaimLeaderboardReward(quest, externalEligibility)
+  if (canClaim) {
+    return 'READY_FOR_CLAIM'
+  } else if (quest.status === 'COMPLETED') {
+    return undefined
+  } else if (quest.status === 'ACTIVE') {
+    return 'ACTIVE'
+  }
+}

--- a/src/helpers/getQueryKeys.ts
+++ b/src/helpers/getQueryKeys.ts
@@ -13,3 +13,7 @@ export function getSyncPlaysessionQueryKey(projectId: string) {
 export function getGetQuestLogInfoQueryKey(questId: string) {
   return ['getQuestLogInfo', questId]
 }
+
+export function getGetExternalEligibilityQueryKey(questId: number | null) {
+  return ['externalEligibility', questId]
+}

--- a/src/hooks/useGetExternalEligibility.ts
+++ b/src/hooks/useGetExternalEligibility.ts
@@ -8,11 +8,11 @@ import { ExternalEligibility } from '@hyperplay/utils'
 import { getGetExternalEligibilityQueryKey } from '@/helpers/getQueryKeys'
 
 type UseGetExternalEligibilityProps = {
-  questId: number | null
+  questId: number
   getExternalEligibility: (
     questId: number
   ) => Promise<ExternalEligibility | null>
-} & Omit<UseQueryOptions<ExternalEligibility | null>, 'queryKey' | 'queryFn'>
+} & Omit<UseQueryOptions<{ questId: number; externalEligibility: ExternalEligibility | null }>, 'queryKey' | 'queryFn'>
 
 export function getExternalEligibilityQueryOptions(
   props: UseGetExternalEligibilityProps
@@ -21,10 +21,8 @@ export function getExternalEligibilityQueryOptions(
   return queryOptions({
     queryKey,
     queryFn: async () => {
-      if (!props.questId) {
-        return null
-      }
-      return props.getExternalEligibility(props.questId)
+      const response = await props.getExternalEligibility(props.questId)
+      return { questId: props.questId, externalEligibility: response }
     },
     ...props
   })

--- a/src/hooks/useGetExternalEligibility.ts
+++ b/src/hooks/useGetExternalEligibility.ts
@@ -12,7 +12,13 @@ type UseGetExternalEligibilityProps = {
   getExternalEligibility: (
     questId: number
   ) => Promise<ExternalEligibility | null>
-} & Omit<UseQueryOptions<{ questId: number; externalEligibility: ExternalEligibility | null }>, 'queryKey' | 'queryFn'>
+} & Omit<
+  UseQueryOptions<{
+    questId: number
+    externalEligibility: ExternalEligibility | null
+  }>,
+  'queryKey' | 'queryFn'
+>
 
 export function getExternalEligibilityQueryOptions(
   props: UseGetExternalEligibilityProps

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ export { claimedRewardToastState } from './state/ClaimedRewardToastState'
 export * from './helpers/getPlaystreakArgsFromQuestData'
 export * from './helpers/getQueryKeys'
 export * from './helpers/getPlaystreakQuestStatus'
-
+export * from './helpers/canClaimReward'
 // types
 export * from './types/quests'
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ export { claimedRewardToastState } from './state/ClaimedRewardToastState'
 export * from './helpers/getPlaystreakArgsFromQuestData'
 export * from './helpers/getQueryKeys'
 export * from './helpers/getPlaystreakQuestStatus'
+export * from './helpers/getExternalQuestStatus'
 export * from './helpers/canClaimReward'
 
 // types

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ export * from './helpers/getPlaystreakArgsFromQuestData'
 export * from './helpers/getQueryKeys'
 export * from './helpers/getPlaystreakQuestStatus'
 export * from './helpers/canClaimReward'
+
 // types
 export * from './types/quests'
 
@@ -25,3 +26,4 @@ export * from './hooks/useInterval'
 export * from './hooks/useSyncPlayStreakWithExternalSource'
 export * from './hooks/useTrackQuestViewed'
 export * from './hooks/useKeepPlaystreaksInSync'
+export * from './hooks/useGetExternalEligibility'

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,6 +14,9 @@ export default defineConfig({
       '@': join(__dirname, 'src')
     }
   },
+  // optimizeDeps: {
+  //   exclude: ['@storybook/react-vite']
+  // },
   plugins: [react(), dts()],
   build: {
     copyPublicDir: true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,9 +14,6 @@ export default defineConfig({
       '@': join(__dirname, 'src')
     }
   },
-  optimizeDeps: {
-    exclude: ['@storybook/react-vite']
-  },
   plugins: [react(), dts()],
   build: {
     copyPublicDir: true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,9 +14,9 @@ export default defineConfig({
       '@': join(__dirname, 'src')
     }
   },
-  // optimizeDeps: {
-  //   exclude: ['@storybook/react-vite']
-  // },
+  optimizeDeps: {
+    exclude: ['@storybook/react-vite']
+  },
   plugins: [react(), dts()],
   build: {
     copyPublicDir: true,


### PR DESCRIPTION
add functions needed in order to add support for external quests in the `useGetQuestStates` hook.