### PR TITLE
[Fix] Claim btn invalidate on claim

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperplay/quests-ui",
-  "version": "0.1.41",
+  "version": "0.1.42",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/components/RewardWrapper/index.tsx
+++ b/src/components/RewardWrapper/index.tsx
@@ -106,7 +106,11 @@ export function RewardWrapper({
     ? Boolean(activeWallet)
     : true
 
-  const { canClaim, isLoading: isCanClaimLoading } = useCanClaimReward({
+  const {
+    canClaim,
+    isLoading: isCanClaimLoading,
+    invalidateQuery: invalidateCanClaimQuery
+  } = useCanClaimReward({
     quest: questMeta,
     getExternalEligibility,
     getUserPlayStreak,
@@ -187,6 +191,7 @@ export function RewardWrapper({
 
       onRewardClaimed?.(reward)
       await invalidateQuestPlayStreakQuery()
+      await invalidateCanClaimQuery()
 
       if (questId !== null) {
         await queryClient.invalidateQueries({

--- a/src/helpers/getQueryKeys.ts
+++ b/src/helpers/getQueryKeys.ts
@@ -17,3 +17,7 @@ export function getGetQuestLogInfoQueryKey(questId: string) {
 export function getGetExternalEligibilityQueryKey(questId: number | null) {
   return ['externalEligibility', questId]
 }
+
+export function getCanClaimRewardQueryKey(questId: number | null) {
+  return ['canClaimReward', questId]
+}

--- a/src/hooks/useCanClaimReward.ts
+++ b/src/hooks/useCanClaimReward.ts
@@ -2,6 +2,7 @@ import {
   canClaimLeaderboardReward,
   canClaimPlayStreakReward
 } from '@/helpers/canClaimReward'
+import { getCanClaimRewardQueryKey } from '@/helpers/getQueryKeys'
 import { Quest, ExternalEligibility, UserPlayStreak } from '@hyperplay/utils'
 import {
   useQueryClient,
@@ -24,7 +25,7 @@ export function useCanClaimReward({
   ...options
 }: Props) {
   const queryClient = useQueryClient()
-  const queryKey = ['canClaimReward', quest.id]
+  const queryKey = getCanClaimRewardQueryKey(quest.id)
   const query = useQuery({
     queryKey,
     queryFn: async () => {
@@ -51,8 +52,6 @@ export function useCanClaimReward({
   return {
     canClaim: query.data,
     ...query,
-    invalidateQuery: () => {
-      queryClient.invalidateQueries({ queryKey })
-    }
+    invalidateQuery: async () => queryClient.invalidateQueries({ queryKey })
   }
 }


### PR DESCRIPTION
# Summary

Invalidate can claim query after minting a reward so the UI reflects the already claimed state

Related to https://github.com/HyperPlay-Gaming/px-pm/issues/306