### PR TITLE
fix: handle user rejection error in the client

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperplay/quests-ui",
-  "version": "0.1.48",
+  "version": "0.1.47",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperplay/quests-ui",
-  "version": "0.1.46",
+  "version": "0.1.48",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/components/RewardWrapper/index.tsx
+++ b/src/components/RewardWrapper/index.tsx
@@ -215,6 +215,8 @@ export function RewardWrapper({
       }
     },
     onError: (error) => {
+      setClaimError(error)
+
       if (errorIsUserRejected(error)) {
         trackEvent({
           event: 'Reward Claim User Rejected',
@@ -223,7 +225,6 @@ export function RewardWrapper({
         return
       }
 
-      setClaimError(error)
       const errorMessage = trackRewardClaimMutationError(error)
 
       logError(`Error claiming rewards: ${error}`, {


### PR DESCRIPTION
This PR started with the goal of adding a test case for user transaction rejection, which is a common scenario. But unlike connection or chain switching errors, Wagmi doesn't provide a built-in way to trigger a transaction rejection.

While [looking into how Wagmi handles rejections in writeContract](https://github.com/HyperPlay-Gaming/quests-ui/blob/feat/claim-error-reject-debug/src/components/RewardWrapper/index.tsx#L481-L509), I found that one of the main issues with reward claims comes from writeContract returning an object instead of throwing or returning a valid transaction hash. This only happens in the client, and I’m not sure why, but I suspect it’s related to how we’re using the **ethers as the provider for MetaMask**.

Because this behavior only happens in the client, reproducing it in tests is tricky. So for now, I’m just handling the issue directly rather than trying to write a test for it.

<img width="1043" alt="Screenshot 2025-05-15 at 6 05 26 PM" src="https://github.com/user-attachments/assets/c8cd3c90-657a-441b-8aa7-aa4b7cce3bd1" />
