### PR TITLE
[Fix] External eligiblity query key collision

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperplay/quests-ui",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/components/QuestDetailsWrapper/ExternalQuest.stories.tsx
+++ b/src/components/QuestDetailsWrapper/ExternalQuest.stories.tsx
@@ -293,6 +293,8 @@ export const InClaimPeriodAndEligible: Story = {
         )
       ).toBeInTheDocument()
     })
-    expect(canvas.getByRole('button', { name: 'Claim' })).toBeEnabled()
+    await waitFor(async () =>
+      expect(canvas.getByRole('button', { name: 'Claim' })).toBeEnabled()
+    )
   }
 }

--- a/src/components/QuestDetailsWrapper/ExternalQuest.stories.tsx
+++ b/src/components/QuestDetailsWrapper/ExternalQuest.stories.tsx
@@ -278,7 +278,8 @@ export const InClaimPeriodAndEligible: Story = {
     getExternalEligibility: async () => {
       return {
         walletOrEmail: '0x123',
-        amount: 1000 * 1e18
+        amount: 1000 * 1e18,
+        questId: 2
       }
     }
   },

--- a/src/components/QuestDetailsWrapper/ExternalQuest.stories.tsx
+++ b/src/components/QuestDetailsWrapper/ExternalQuest.stories.tsx
@@ -279,7 +279,7 @@ export const InClaimPeriodAndEligible: Story = {
       return {
         walletOrEmail: '0x123',
         amount: 1000 * 1e18,
-        questId: 2
+        questId: mockQuest.id
       }
     }
   },

--- a/src/components/RewardsBanner/LeaderboardBanner/index.tsx
+++ b/src/components/RewardsBanner/LeaderboardBanner/index.tsx
@@ -110,13 +110,10 @@ export function LeaderboardBanner({
   }
 
   if (quest.status === 'CLAIMABLE') {
-    if (!eligibilityData?.externalEligibility) {
+    if (!eligibilityData) {
       return notEligibleMessage
     }
-    const userCanClaimReward = canClaimLeaderboardReward(
-      quest,
-      eligibilityData.externalEligibility
-    )
+    const userCanClaimReward = canClaimLeaderboardReward(quest, eligibilityData)
     return userCanClaimReward ? claimableMessage : notEligibleMessage
   }
 

--- a/src/components/RewardsWrapper/RewardWrapper.stories.tsx
+++ b/src/components/RewardsWrapper/RewardWrapper.stories.tsx
@@ -94,7 +94,7 @@ export const LeaderboardQuestEligible: Story = {
         return {
           walletOrEmail: '0x123',
           amount: 100000000000000000000,
-          questId: 1
+          questId: mockQuest.id
         }
       },
       getQuest: async () => {

--- a/src/components/RewardsWrapper/RewardWrapper.stories.tsx
+++ b/src/components/RewardsWrapper/RewardWrapper.stories.tsx
@@ -93,7 +93,8 @@ export const LeaderboardQuestEligible: Story = {
       getExternalEligibility: async () => {
         return {
           walletOrEmail: '0x123',
-          amount: 100000000000000000000
+          amount: 100000000000000000000,
+          questId: 1
         }
       },
       getQuest: async () => {

--- a/src/helpers/queryProps.ts
+++ b/src/helpers/queryProps.ts
@@ -1,17 +1,17 @@
-import { ExternalEligibility, Quest } from '@hyperplay/utils'
+import { ExternalEligibilityWithQuestId } from '@/types/quests'
 import { getGetExternalEligibilityQueryKey } from './getQueryKeys'
 
 export function getExternalEligibilityQueryProps({
-  quest,
+  questId,
   getExternalEligibility
 }: {
-  quest: Quest
+  questId: number
   getExternalEligibility: (
     questId: number
-  ) => Promise<ExternalEligibility | null>
+  ) => Promise<ExternalEligibilityWithQuestId | null>
 }) {
   return {
-    queryKey: getGetExternalEligibilityQueryKey(quest.id),
-    queryFn: async () => getExternalEligibility(quest.id)
+    queryKey: getGetExternalEligibilityQueryKey(questId),
+    queryFn: async () => getExternalEligibility(questId)
   }
 }

--- a/src/hooks/useCanClaimReward.ts
+++ b/src/hooks/useCanClaimReward.ts
@@ -4,7 +4,8 @@ import {
 } from '@/helpers/canClaimReward'
 import { getCanClaimRewardQueryKey } from '@/helpers/getQueryKeys'
 import { getExternalEligibilityQueryProps } from '@/helpers/queryProps'
-import { Quest, ExternalEligibility, UserPlayStreak } from '@hyperplay/utils'
+import { ExternalEligibilityWithQuestId } from '@/types/quests'
+import { Quest, UserPlayStreak } from '@hyperplay/utils'
 import {
   useQueryClient,
   useQuery,
@@ -15,7 +16,7 @@ type Props = {
   quest: Quest
   getExternalEligibility: (
     questId: number
-  ) => Promise<ExternalEligibility | null>
+  ) => Promise<ExternalEligibilityWithQuestId | null>
   getUserPlayStreak: (questId: number) => Promise<UserPlayStreak>
 } & Omit<UseQueryOptions<boolean>, 'queryKey' | 'queryFn'>
 
@@ -33,7 +34,7 @@ export function useCanClaimReward({
       if (quest.type === 'LEADERBOARD') {
         const externalEligibility = await queryClient.ensureQueryData(
           getExternalEligibilityQueryProps({
-            quest,
+            questId: quest.id,
             getExternalEligibility
           })
         )

--- a/src/hooks/useGetExternalEligibility.ts
+++ b/src/hooks/useGetExternalEligibility.ts
@@ -4,32 +4,28 @@ import {
   useQueryClient,
   UseQueryOptions
 } from '@tanstack/react-query'
-import { ExternalEligibility } from '@hyperplay/utils'
-import { getGetExternalEligibilityQueryKey } from '@/helpers/getQueryKeys'
+import { getExternalEligibilityQueryProps } from '@/helpers/queryProps'
+import { ExternalEligibilityWithQuestId } from '@/types/quests'
 
 type UseGetExternalEligibilityProps = {
   questId: number
   getExternalEligibility: (
     questId: number
-  ) => Promise<ExternalEligibility | null>
+  ) => Promise<ExternalEligibilityWithQuestId | null>
 } & Omit<
-  UseQueryOptions<{
-    questId: number
-    externalEligibility: ExternalEligibility | null
-  }>,
+  UseQueryOptions<ExternalEligibilityWithQuestId | null>,
   'queryKey' | 'queryFn'
 >
 
 export function getExternalEligibilityQueryOptions(
   props: UseGetExternalEligibilityProps
 ) {
-  const queryKey = getGetExternalEligibilityQueryKey(props.questId)
+  const queryProps = getExternalEligibilityQueryProps({
+    questId: props.questId,
+    getExternalEligibility: props.getExternalEligibility
+  })
   return queryOptions({
-    queryKey,
-    queryFn: async () => {
-      const response = await props.getExternalEligibility(props.questId)
-      return { questId: props.questId, externalEligibility: response }
-    },
+    ...queryProps,
     ...props
   })
 }

--- a/src/hooks/useGetQuestStates.ts
+++ b/src/hooks/useGetQuestStates.ts
@@ -1,11 +1,12 @@
 import { QuestLogInfo } from '@hyperplay/ui'
-import { Quest, UserPlayStreak, ExternalEligibility } from '@hyperplay/utils'
+import { Quest, UserPlayStreak } from '@hyperplay/utils'
 import { useQueries } from '@tanstack/react-query'
 import { getQuestQueryOptions } from './useGetQuest'
 import { getUserPlaystreakQueryOptions } from './useGetUserPlayStreak'
 import { getExternalEligibilityQueryOptions } from './useGetExternalEligibility'
 import { getPlaystreakQuestStatus } from '@/helpers/getPlaystreakQuestStatus'
 import { getExternalQuestStatus } from '@/helpers/getExternalQuestStatus'
+import { ExternalEligibilityWithQuestId } from '@/types/quests'
 
 type getQuestQueryOptionsType = ReturnType<typeof getQuestQueryOptions>
 type getUserPlaystreakQueryOptionsType = ReturnType<
@@ -21,7 +22,7 @@ type Props = {
   getUserPlayStreak: (questId: number) => Promise<UserPlayStreak>
   getExternalEligibility: (
     questId: number
-  ) => Promise<ExternalEligibility | null>
+  ) => Promise<ExternalEligibilityWithQuestId | null>
   enabled?: boolean
   isSignedIn?: boolean
 }
@@ -113,7 +114,7 @@ export function useGetQuestStates({
     const questData = questMap[questId]
     questIdToQuestStateMap[questId] = getExternalQuestStatus(
       questData,
-      val.data.externalEligibility
+      val.data
     )
   })
 

--- a/src/hooks/useGetRewards.ts
+++ b/src/hooks/useGetRewards.ts
@@ -44,7 +44,7 @@ export function useGetRewards({
         if (questMeta.type === 'LEADERBOARD') {
           const externalEligibility = await queryClient.ensureQueryData(
             getExternalEligibilityQueryProps({
-              quest: questMeta,
+              questId: questMeta.id,
               getExternalEligibility
             })
           )

--- a/src/types/quests.ts
+++ b/src/types/quests.ts
@@ -15,6 +15,10 @@ import { TrackEventFn } from './analytics'
 
 export type UseGetRewardsData = QuestReward & Reward
 
+export type ExternalEligibilityWithQuestId = ExternalEligibility & {
+  questId: number
+}
+
 export class ClaimError extends Error {
   properties: any
 
@@ -42,7 +46,7 @@ export interface QuestWrapperContextValue {
   }
   getExternalEligibility: (
     questId: number
-  ) => Promise<ExternalEligibility | null>
+  ) => Promise<ExternalEligibilityWithQuestId | null>
   getQuest: (questId: number) => Promise<Quest>
   getActiveWallet: () => Promise<string | null | undefined>
   getGameplayWallets: () => Promise<{ id: number; wallet_address: string }[]>


### PR DESCRIPTION
# Summary

There was a query key collision for get external eligibility so  this was returned 

`{ questId: props.questId, externalEligibility: response }`

when just `externalEligibility` was expected.

Also `${DEV_PORTAL_URL}/api/v1/quests/${questId}/eligibility/external` was returning 

```
{
  questId: number,
  walletOrEmail: string,
  amount: number
}
```

so I changed it to just return that. Also defined the get external eligibility queryFn in one place to prevent in the future.