### PR TITLE
[Fix] Add redundant checksum 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperplay/quests-ui",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/components/ActiveWalletSection/index.tsx
+++ b/src/components/ActiveWalletSection/index.tsx
@@ -14,6 +14,7 @@ import {
   canClaimRewardQueryKeyPrefix,
   eligibilityQueryKeyPrefixes
 } from '@/helpers/getQueryKeys'
+import { getAddress } from 'viem'
 
 const { WarningIcon, AlertOctagon } = Images
 
@@ -94,7 +95,10 @@ function InputLikeContainer({
 
 export default function ActiveWalletSection() {
   const queryClient = useQueryClient()
-  const { address: connectedWallet, connector } = useAccount()
+  const { address: connectedWalletRaw, connector } = useAccount()
+  const connectedWallet = connectedWalletRaw
+    ? getAddress(connectedWalletRaw)
+    : connectedWalletRaw
   const {
     getActiveWallet,
     setActiveWallet,

--- a/src/components/RewardWrapper/index.tsx
+++ b/src/components/RewardWrapper/index.tsx
@@ -17,6 +17,7 @@ import {
   BaseError,
   ContractFunctionRevertedError,
   createPublicClient,
+  getAddress,
   http,
   UserRejectedRequestError
 } from 'viem'
@@ -226,8 +227,9 @@ export function RewardWrapper({
     mutationFn: async (params: UseGetRewardsData) => {
       const firstTimeHolderResult = checkIsFirstTimeHolder({
         rewardType: reward.reward_type,
-        accountAddress:
-          account.address ?? '0x0000000000000000000000000000000000000000',
+        accountAddress: getAddress(
+          account.address ?? '0x0000000000000000000000000000000000000000'
+        ),
         contractAddress: reward.contract_address,
         logError,
         config
@@ -340,7 +342,7 @@ export function RewardWrapper({
     }
 
     if (account.address && connectionHasSwitchChain) {
-      address = account.address
+      address = getAddress(account.address)
     } else {
       onShowMetaMaskPopup?.()
       logInfo('connecting to wallet...')


### PR DESCRIPTION
WC connector sometimes returns a non-checksummed address, which messes up the UI. Let's add a redundant check to be robust against this