### PR TITLE
[Fix] Call openWalletConnectionModal if account unconnected

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperplay/quests-ui",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/components/QuestDetailsWrapper/ExternalQuest.stories.tsx
+++ b/src/components/QuestDetailsWrapper/ExternalQuest.stories.tsx
@@ -195,7 +195,7 @@ export const NotSignedIn: Story = {
     expect(
       canvas.getByText('Log into HyperPlay to track quest eligibility')
     ).toBeInTheDocument()
-    expect(canvas.queryByRole('button', { name: 'Claim' })).toBeDisabled()
+    expect(canvas.queryByRole('button', { name: 'Connect' })).toBeDisabled()
   }
 }
 
@@ -207,7 +207,7 @@ export const InProgressQuest: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
     await waitForLoadingSpinnerToDisappear(canvas)
-    expect(canvas.queryByRole('button', { name: 'Claim' })).toBeDisabled()
+    expect(canvas.queryByRole('button', { name: 'Connect' })).toBeDisabled()
   }
 }
 
@@ -235,7 +235,7 @@ export const InWaitPeriod: Story = {
         )
       ).toBeInTheDocument()
     })
-    expect(canvas.queryByRole('button', { name: 'Claim' })).toBeDisabled()
+    expect(canvas.queryByRole('button', { name: 'Connect' })).toBeDisabled()
   }
 }
 
@@ -261,7 +261,7 @@ export const InClaimPeriodAndNotEligible: Story = {
         canvas.getByText("You didn't qualify for a reward")
       ).toBeInTheDocument()
     })
-    expect(canvas.queryByRole('button', { name: 'Claim' })).toBeDisabled()
+    expect(canvas.queryByRole('button', { name: 'Connect' })).toBeDisabled()
   }
 }
 
@@ -300,7 +300,7 @@ export const InClaimPeriodAndEligible: Story = {
       ).toBeInTheDocument()
     })
     await waitFor(async () =>
-      expect(canvas.getByRole('button', { name: 'Claim' })).toBeEnabled()
+      expect(canvas.getByRole('button', { name: 'Connect' })).toBeEnabled()
     )
   }
 }

--- a/src/components/QuestDetailsWrapper/PlayStreakQuest.stories.tsx
+++ b/src/components/QuestDetailsWrapper/PlayStreakQuest.stories.tsx
@@ -2,13 +2,17 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { QuestDetailsWrapper, QuestDetailsWrapperProps } from './index'
 import styles from './story-styles.module.scss'
 import { Quest, UserPlayStreak } from '@hyperplay/utils'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { verifyMessage, BrowserProvider } from 'ethers'
 import { generateNonce, SiweMessage } from 'siwe'
-import { useAccount } from 'wagmi'
+import { injected, useAccount, useConnect } from 'wagmi'
 import { within, expect, waitFor, fn } from '@storybook/test'
 import { createQueryClientDecorator } from '@/helpers/createQueryClientDecorator'
-import { waitForLoadingSpinnerToDisappear } from '@/utils/storybook/quest-wrapper'
+import {
+  expectAllCTAsToBeDisabled,
+  waitForAllCTAsToBeEnabled,
+  waitForLoadingSpinnerToDisappear
+} from '@/utils/storybook/quest-wrapper'
 import { InjectedProviderMock } from '@/mocks/injectedProvider'
 
 const meta: Meta<typeof QuestDetailsWrapper> = {
@@ -249,9 +253,7 @@ export const QuestPageNotSignedIn: Story = {
       canvas.getByText('Log into HyperPlay to track quest eligibility')
     ).toBeVisible()
     expect(canvas.getByRole('button', { name: /play/i })).toBeDisabled()
-    canvas.getAllByRole('button', { name: /claim/i }).forEach((button) => {
-      expect(button).toBeDisabled()
-    })
+    await expectAllCTAsToBeDisabled(canvasElement)
   }
 }
 
@@ -267,9 +269,7 @@ export const QuestPageSignedIn: Story = {
     expect(
       canvas.queryByText('Log into HyperPlay to track quest eligibility')
     ).not.toBeInTheDocument()
-    canvas.getAllByRole('button', { name: /claim/i }).forEach((button) => {
-      expect(button).toBeDisabled()
-    })
+    await expectAllCTAsToBeDisabled(canvasElement)
   }
 }
 
@@ -288,9 +288,7 @@ export const QuestPageSignedInNoActiveWallet: Story = {
       )
     ).toBeVisible()
     expect(canvas.getByRole('button', { name: /play/i })).toBeDisabled()
-    canvas.getAllByRole('button', { name: /claim/i }).forEach((button) => {
-      expect(button).toBeDisabled()
-    })
+    await expectAllCTAsToBeDisabled(canvasElement)
   }
 }
 
@@ -313,9 +311,7 @@ export const QuestPageSignedInWithActiveWallet: Story = {
     })
 
     expect(canvas.getByRole('button', { name: /play/i })).toBeEnabled()
-    canvas.getAllByRole('button', { name: /claim/i }).forEach((button) => {
-      expect(button).toBeDisabled()
-    })
+    await expectAllCTAsToBeDisabled(canvasElement)
   }
 }
 
@@ -340,7 +336,7 @@ export const QuestPageSignedInEligible: Story = {
 
     // await for the claim button to be enabled
     await waitFor(() => {
-      canvas.getAllByRole('button', { name: /claim/i }).forEach((button) => {
+      canvas.getAllByRole('button', { name: /Connect/i }).forEach((button) => {
         expect(button).toBeEnabled()
       })
     })
@@ -367,13 +363,7 @@ export const QuestPageSignedInEligibleNoActiveWalletRequired: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
     await waitForLoadingSpinnerToDisappear(canvas)
-
-    // await for the claim button to be enabled
-    await waitFor(() => {
-      canvas.getAllByRole('button', { name: /claim/i }).forEach((button) => {
-        expect(button).toBeEnabled()
-      })
-    })
+    await waitForAllCTAsToBeEnabled(canvasElement)
   }
 }
 
@@ -407,11 +397,7 @@ export const OverlaySignedInEligible: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
     await waitForLoadingSpinnerToDisappear(canvas)
-    await waitFor(() => {
-      canvas.getAllByRole('button', { name: /claim/i }).forEach((button) => {
-        expect(button).toBeEnabled()
-      })
-    })
+    await waitForAllCTAsToBeEnabled(canvasElement)
   }
 }
 
@@ -599,7 +585,11 @@ export const TestSwitchToChainNoEIP3085: Story = {
   ],
   render: (args) => {
     const activeWallet = window.ethereum.address
+    const { connect } = useConnect()
     const { address } = useAccount()
+    useEffect(() => {
+      connect({ connector: injected() })
+    }, [])
     return (
       <QuestDetailsWrapper
         {...args}

--- a/src/components/QuestDetailsWrapper/PlayStreakQuest.stories.tsx
+++ b/src/components/QuestDetailsWrapper/PlayStreakQuest.stories.tsx
@@ -674,3 +674,62 @@ export const TestSwitchToChainNoEIP3085: Story = {
     })
   }
 }
+
+const windowEth2 = new InjectedProviderMock()
+
+export const TestConnectButton: Story = {
+  args: {
+    ...mockProps
+  },
+  decorators: [
+    (Story) => {
+      window.ethereum = windowEth2
+      return <Story />
+    }
+  ],
+  render: (args) => {
+    const { connect } = useConnect()
+    const activeWallet = window.ethereum.address
+    return (
+      <QuestDetailsWrapper
+        {...args}
+        getActiveWallet={async () => Promise.resolve(activeWallet)}
+        getGameplayWallets={async () => [
+          { id: 1, wallet_address: activeWallet ?? '' }
+        ]}
+        getUserPlayStreak={async (): Promise<UserPlayStreak> => {
+          return {
+            current_playstreak_in_days: 5,
+            completed_counter: 3,
+            accumulated_playtime_today_in_seconds: 1800,
+            last_play_session_completed_datetime: new Date().toISOString()
+          }
+        }}
+        getQuest={async () => {
+          const mockQuestOneApeChainReward: Quest = {
+            ...mockQuest,
+            rewards: mockQuest.rewards?.slice(0, 1)
+          }
+          return mockQuestOneApeChainReward
+        }}
+        openWalletConnectionModal={() => {
+          connect({ connector: injected() })
+        }}
+      />
+    )
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const claimButton = await waitFor(async () => {
+      const button = (await canvas.findByRole('button', {
+        name: /Connect/i
+      })) as HTMLButtonElement
+      if (button && !button.disabled) {
+        return button
+      }
+      throw new Error('Claim button is not enabled')
+    })
+    claimButton.click()
+    await waitForAllCTAsToBeEnabled(canvasElement)
+  }
+}

--- a/src/components/RewardWrapper/index.tsx
+++ b/src/components/RewardWrapper/index.tsx
@@ -442,7 +442,8 @@ export function RewardWrapper({
       case 'ERC1155':
       case 'ERC721':
       case 'ERC20':
-        return mintOnChainReward(reward)
+        await mintOnChainReward(reward)
+        break
       case 'POINTS':
         await claimPoints(reward)
         break

--- a/src/components/RewardsWrapper/RewardWrapper.stories.tsx
+++ b/src/components/RewardsWrapper/RewardWrapper.stories.tsx
@@ -124,7 +124,7 @@ export const LeaderboardQuestEligible: Story = {
     )
     expect(canvas.getByText('+100 MNT')).toBeInTheDocument()
     waitFor(() => {
-      expect(canvas.getByRole('button', { name: 'Claim' })).toBeEnabled()
+      expect(canvas.getByRole('button', { name: 'Connect' })).toBeEnabled()
     })
   }
 }
@@ -167,6 +167,6 @@ export const EligibleButQuestTypeClaimDisabled: Story = {
       canvas.getByLabelText('loading rewards')
     )
     expect(canvas.getByText('+100 MNT')).toBeInTheDocument()
-    expect(canvas.getByRole('button', { name: 'Claim' })).toBeDisabled()
+    expect(canvas.getByRole('button', { name: 'Connect' })).toBeDisabled()
   }
 }

--- a/src/helpers/checkIsFirstTimeHolder.ts
+++ b/src/helpers/checkIsFirstTimeHolder.ts
@@ -1,7 +1,7 @@
 import { QuestWrapperContextValue } from '@/types/quests'
 import { Reward } from '@hyperplay/utils'
 import { readContract } from '@wagmi/core'
-import { erc20Abi } from 'viem'
+import { erc20Abi, getAddress } from 'viem'
 import { Config } from 'wagmi'
 
 export async function checkIsFirstTimeHolder({
@@ -12,12 +12,16 @@ export async function checkIsFirstTimeHolder({
   config
 }: {
   rewardType: Reward['reward_type']
-  accountAddress: `0x${string}`
+  accountAddress: `0x${string}` | undefined
   contractAddress: Reward['contract_address']
   logError: QuestWrapperContextValue['logError']
   config: Config
 }) {
   let isFirstTimeHolder = false
+  // this prevents the balance call with the 0x0 address
+  if (accountAddress === undefined) {
+    return false
+  }
 
   // check balance before claim
   try {
@@ -26,7 +30,11 @@ export async function checkIsFirstTimeHolder({
         abi: erc20Abi,
         address: contractAddress,
         functionName: 'balanceOf',
-        args: [accountAddress]
+        args: [
+          getAddress(
+            accountAddress ?? '0x0000000000000000000000000000000000000000'
+          )
+        ]
       })
       isFirstTimeHolder = erc20Balance === BigInt(0)
     }

--- a/src/helpers/checkIsFirstTimeHolder.ts
+++ b/src/helpers/checkIsFirstTimeHolder.ts
@@ -20,7 +20,7 @@ export async function checkIsFirstTimeHolder({
   let isFirstTimeHolder = false
   // this prevents the balance call with the 0x0 address
   if (accountAddress === undefined) {
-    return false
+    return { isFirstTimeHolder: false }
   }
 
   // check balance before claim
@@ -30,11 +30,7 @@ export async function checkIsFirstTimeHolder({
         abi: erc20Abi,
         address: contractAddress,
         functionName: 'balanceOf',
-        args: [
-          getAddress(
-            accountAddress ?? '0x0000000000000000000000000000000000000000'
-          )
-        ]
+        args: [getAddress(accountAddress)]
       })
       isFirstTimeHolder = erc20Balance === BigInt(0)
     }

--- a/src/helpers/claimErrors.ts
+++ b/src/helpers/claimErrors.ts
@@ -1,3 +1,4 @@
+import { NoAccountConnectedError } from '@/types/quests'
 import { SwitchChainError, UserRejectedRequestError } from 'viem'
 
 export function errorIsSwitchChainError(
@@ -10,4 +11,10 @@ export function errorIsUserRejected(
   error: Error
 ): error is UserRejectedRequestError {
   return error instanceof UserRejectedRequestError
+}
+
+export function errorIsNoAccountConnectedError(
+  error: Error
+): error is NoAccountConnectedError {
+  return error instanceof NoAccountConnectedError
 }

--- a/src/types/quests.ts
+++ b/src/types/quests.ts
@@ -105,4 +105,5 @@ export interface QuestWrapperContextValue {
   onRewardClaimed?: (reward: Reward) => void
   onShowMetaMaskPopup?: () => void
   getListingById?: (projectId: string) => Promise<Listing>
+  openWalletConnectionModal?: () => void
 }

--- a/src/types/quests.ts
+++ b/src/types/quests.ts
@@ -46,6 +46,13 @@ export class NotEnoughGasError extends Error {
   }
 }
 
+export class NoAccountConnectedError extends Error {
+  constructor() {
+    super('No account connected')
+    this.name = 'NoAccountConnectedError'
+  }
+}
+
 export interface QuestWrapperContextValue {
   flags: {
     rewardTypeClaimEnabled: Record<Reward['reward_type'], boolean>

--- a/src/utils/storybook/quest-wrapper.ts
+++ b/src/utils/storybook/quest-wrapper.ts
@@ -1,4 +1,9 @@
-import { waitForElementToBeRemoved, within } from '@storybook/test'
+import {
+  waitFor,
+  waitForElementToBeRemoved,
+  within,
+  expect
+} from '@storybook/test'
 
 export async function waitForLoadingSpinnerToDisappear(
   canvas: ReturnType<typeof within>
@@ -10,4 +15,25 @@ export async function waitForLoadingSpinnerToDisappear(
   await waitForElementToBeRemoved(() =>
     canvas.getByLabelText('loading rewards')
   )
+}
+
+export async function expectAllCTAsToBeDisabled(canvasElement: HTMLElement) {
+  const canvas = within(canvasElement)
+  await Promise.all(
+    Array.from(canvas.getAllByRole('button', { name: /Connect/i })).map(
+      async (button) => {
+        await expect(button).toBeDisabled()
+      }
+    )
+  )
+}
+
+export async function waitForAllCTAsToBeEnabled(canvasElement: HTMLElement) {
+  const canvas = within(canvasElement)
+  // await for the claim button to be enabled
+  await waitFor(() => {
+    canvas.getAllByRole('button', { name: /Connect/i }).forEach((button) => {
+      expect(button).toBeEnabled()
+    })
+  })
 }


### PR DESCRIPTION
# Summary

Instead of assuming injected provider, let's allow the consuming code to show whichever wallet onboarding modal they support.

If a wallet isn't connect, show "Connect" instead of "Claim" to make this UX intuitive.

Also includes a fix to the first time holder balance check