### PR TITLE
[Fix] add chain id to first time holder check

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperplay/quests-ui",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/components/QuestDetailsWrapper/PlayStreakQuest.stories.tsx
+++ b/src/components/QuestDetailsWrapper/PlayStreakQuest.stories.tsx
@@ -5,7 +5,7 @@ import { Quest, UserPlayStreak } from '@hyperplay/utils'
 import { useEffect, useState } from 'react'
 import { verifyMessage, BrowserProvider } from 'ethers'
 import { generateNonce, SiweMessage } from 'siwe'
-import { injected, useAccount, useConnect } from 'wagmi'
+import { injected, useAccount, useConnect, useDisconnect } from 'wagmi'
 import { within, expect, waitFor, fn } from '@storybook/test'
 import { createQueryClientDecorator } from '@/helpers/createQueryClientDecorator'
 import {
@@ -689,6 +689,10 @@ export const TestConnectButton: Story = {
   ],
   render: (args) => {
     const { connect } = useConnect()
+    const { disconnect } = useDisconnect()
+    useEffect(() => {
+      disconnect()
+    }, [])
     const activeWallet = window.ethereum.address
     return (
       <QuestDetailsWrapper

--- a/src/components/RewardWrapper/index.tsx
+++ b/src/components/RewardWrapper/index.tsx
@@ -228,6 +228,7 @@ export function RewardWrapper({
         accountAddress: account.address,
         contractAddress: reward.contract_address,
         logError,
+        rewardChainId: reward.chain_id,
         config
       })
 

--- a/src/helpers/checkIsFirstTimeHolder.ts
+++ b/src/helpers/checkIsFirstTimeHolder.ts
@@ -9,17 +9,19 @@ export async function checkIsFirstTimeHolder({
   accountAddress,
   contractAddress,
   logError,
+  rewardChainId,
   config
 }: {
   rewardType: Reward['reward_type']
   accountAddress: `0x${string}` | undefined
   contractAddress: Reward['contract_address']
   logError: QuestWrapperContextValue['logError']
+  rewardChainId: number | null
   config: Config
 }) {
   let isFirstTimeHolder = false
   // this prevents the balance call with the 0x0 address
-  if (accountAddress === undefined) {
+  if (accountAddress === undefined || rewardChainId === null) {
     return { isFirstTimeHolder: false }
   }
 
@@ -30,7 +32,8 @@ export async function checkIsFirstTimeHolder({
         abi: erc20Abi,
         address: contractAddress,
         functionName: 'balanceOf',
-        args: [getAddress(accountAddress)]
+        args: [getAddress(accountAddress)],
+        chainId: rewardChainId
       })
       isFirstTimeHolder = erc20Balance === BigInt(0)
     }


### PR DESCRIPTION
Wagmi will pull from the connected chain. If we pass chain id, it will use the config rpc for that chain id, which is the intended behavior