### PR TITLE
[Fix] cta for points quests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperplay/quests-ui",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/components/RewardWrapper/index.tsx
+++ b/src/components/RewardWrapper/index.tsx
@@ -39,6 +39,17 @@ import {
 import { useGetListingByProjectId } from '@/hooks/useGetListingById'
 import { checkIsFirstTimeHolder } from '@/helpers/checkIsFirstTimeHolder'
 
+const rewardDoesNotNeedAConnectedWallet: Record<
+  Reward['reward_type'],
+  boolean
+> = {
+  ERC20: false,
+  ERC721: false,
+  ERC1155: false,
+  POINTS: true,
+  'EXTERNAL-TASKS': true
+}
+
 const getClaimEventProperties = (reward: Reward, questId: number | null) => {
   /* eslint-disable @typescript-eslint/no-unused-vars */
   const {
@@ -539,6 +550,14 @@ export function RewardWrapper({
     !errorIsUserRejected(claimError) &&
     !errorIsNoAccountConnectedError(claimError)
 
+  let claimText = 'Connect'
+  if (
+    account.isConnected ||
+    rewardDoesNotNeedAConnectedWallet[reward.reward_type]
+  ) {
+    claimText = 'Claim'
+  }
+
   return (
     <div className={styles.rewardContainer}>
       <RewardUi
@@ -554,7 +573,7 @@ export function RewardWrapper({
           claimsLeft: 'Claims left',
           viewReward: 'View Reward',
           claimed: 'Claimed',
-          claim: account.isConnected ? 'Claim' : 'Connect',
+          claim: claimText,
           claimNotAvailable: "This reward isn't available to claim right now."
         }}
       />

--- a/src/components/RewardsWrapper/RewardWrapper.stories.tsx
+++ b/src/components/RewardsWrapper/RewardWrapper.stories.tsx
@@ -243,3 +243,25 @@ export const EligibleButHasExistingSignature: Story = {
     })
   }
 }
+
+export const PointsReward: Story = {
+  decorators: [
+    createQuestWrapperDecorator({
+      getQuest: async () => {
+        return {
+          ...mockQuest,
+          type: 'LEADERBOARD',
+          rewards: [ {...mockReward[0], reward_type: 'POINTS'} ]
+        }
+      }
+    })
+  ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    // await for the claim button to be enabled
+    await waitFor(() => {
+      expect(canvas
+        .getAllByRole('button', { name: /Claim/i }).length).toBeGreaterThan(0)
+    })
+  }
+}


### PR DESCRIPTION
# Summary

There was a regression where "POINTS" rewards were showing "Connect" instead of "Claim" and clicking "Connect" would actually claim the reward.

closes https://github.com/HyperPlay-Gaming/hyperplay-pm/issues/651